### PR TITLE
Disable "Chapter" label for section headings

### DIFF
--- a/docs/config/setup.adoc
+++ b/docs/config/setup.adoc
@@ -1,5 +1,6 @@
 :doctype: book
 :icons: font
+:chapter-label: 
 :sectnumlevels: 1
 
 


### PR DESCRIPTION
Applying this PR will remove the "Chapter" part of section headings. 

Example:
```
Chapter 1. Einleitung
```
will become
```
1. Einleitung
```